### PR TITLE
Remove Python 3.6 from travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "3.6"
   - "3.7"
   - "3.8"
   - "3.9"


### PR DESCRIPTION
### Notes 
Python 3.6 reached EOL on 2021-12-23

### Testing
* pytest