### PR TITLE
Fix coverage reporting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
           pip install -r requirements.txt
       - name: Run Tests
         run: |
-          pytest --cov=tests --cov-report=xml
+          pytest --cov=purenes --cov-report=xml
       - name: Report Coverage
         run: |
           export CODECOV_TOKEN=e84b34b7-becd-439d-918f-138e5ad30321

--- a/purenes/cpu.py
+++ b/purenes/cpu.py
@@ -1,8 +1,8 @@
 # Python 3.7 and 3.8 support
 try:
-    from typing import Final
-except ImportError:
-    from typing_extensions import Final
+    from typing import Final  # pragma: no cover
+except ImportError:  # pragma: no cover
+    from typing_extensions import Final  # pragma: no cover
 from typing import List
 
 


### PR DESCRIPTION
### Notes

The previous workflow was running coverage tests on the test directory itself.

1. This change updates directory to purenes from tests.
2. Adds # pragma: no cover to import statements that differ between Python versions as it is not possible to cover all branches of these lines.

### Testing
* `pytest --cov=purenes`