### PR TITLE
Implement $2007 write

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,7 +22,7 @@ copyright = '2022, Stephen Brady'
 author = 'Stephen Brady'
 
 # The full version, including alpha/beta/rc tags
-release = '0.14.2'
+release = '0.15.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/purenes/ppu.py
+++ b/purenes/ppu.py
@@ -345,6 +345,15 @@ class PPU(object):
                     self._vram.reg = self._vram_temp.reg
                     self._write_latch = 0
 
+            if _address == 0x0007:
+                # Preserve space
+                i = self._control.flags.vram_address_increment
+
+                # Writing to $2007 does not impact the internal
+                # _data_read_buffer
+                self._write(self._vram.reg, data)
+                self._vram.reg += 1 if i == 0 else 32
+
     def reset(self) -> None:
         """Perform a reset of the PPU.
 
@@ -435,3 +444,7 @@ class PPU(object):
     def _read(self, address: int) -> int:
         # Internal read.
         return self._ppu_bus.read(address)
+
+    def _write(self, address: int, data: int) -> None:
+        # Internal write.
+        return self._ppu_bus.write(address, data)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import semver
 from setuptools import setup
 from setuptools import find_packages
 
-version = semver.VersionInfo.parse('0.14.2')
+version = semver.VersionInfo.parse('0.15.0')
 
 setup(name='purenes',
       version=str(version),

--- a/tests/ppu/test_ppu.py
+++ b/tests/ppu/test_ppu.py
@@ -79,6 +79,40 @@ class TestPPU(object):
         assert(vram.reg == vram_temp.reg)
         assert(test_object.write_latch == 0)
 
+    def test_data_write_x_increment(self, test_object, mock_ppu_bus, mocker):
+        # Test PPUDATA $2007 write x increment.
+        #
+        # Test that successive writes to the data register with increment_mode
+        # 0 increments the vram address by one byte.
+        address = 0x2007
+        data = 0x01
+
+        test_object.write(address, data)
+        test_object.write(address, data)
+
+        mock_ppu_bus.write.assert_has_calls([
+            mocker.call.write(0x0000, 0x01),
+            mocker.call.write(0x0001, 0x01)
+        ])
+
+    def test_data_write_y_increment(self, test_object, mock_ppu_bus, mocker):
+        # Test PPUDATA $2007 write y increment.
+        #
+        # Test that successive writes to the data register with increment_mode
+        # 1 increments the vram address by 32 bytes.
+        address = 0x2007
+        data = 0x01
+
+        test_object.write(0x2000, 0x4)
+
+        test_object.write(address, data)
+        test_object.write(address, data)
+
+        mock_ppu_bus.write.assert_has_calls([
+            mocker.call.write(0x0000, 0x01),
+            mocker.call.write(0x0020, 0x01)
+        ])
+
     def test_status_read(self, test_object):
         address = 0x2002
 


### PR DESCRIPTION
### Notes

Adds the necessary functionality to read data from the PPUBus through memory-mapped register $2007.

1. Adds support for reading from $2007 including all increment logic.
2. Add tests for x and y increments
3. Minor version bump 0.14.2 -> 0.15.0

### Testing
* pytest