### PR TITLE
Implement $2005 write

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,7 +22,7 @@ copyright = '2022, Stephen Brady'
 author = 'Stephen Brady'
 
 # The full version, including alpha/beta/rc tags
-release = '0.15.0'
+release = '0.16.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import semver
 from setuptools import setup
 from setuptools import find_packages
 
-version = semver.VersionInfo.parse('0.15.0')
+version = semver.VersionInfo.parse('0.16.0')
 
 setup(name='purenes',
       version=str(version),


### PR DESCRIPTION
### Notes

Adds the necessary functionality to set values through memory-mapped register $2005.

1. Adds support for writing to $2005
2. Adds tests
3. Minor version bump 0.15.0 -> 0.16.0

### Testing 
* pytest
* Verified coverage was not impacted

```
Name                  Stmts   Miss  Cover
-----------------------------------------
purenes/__init__.py       0      0   100%
purenes/cpu.py           45      1    98%
purenes/ppu.py          109      0   100%
-----------------------------------------
TOTAL                   154      1    99%
```