### PR TITLE
Fix bug causing writes to $2006 to set flags incorrectly in _Address

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,7 +22,7 @@ copyright = '2022, Stephen Brady'
 author = 'Stephen Brady'
 
 # The full version, including alpha/beta/rc tags
-release = '0.17.1'
+release = '0.17.2'
 
 
 # -- General configuration ---------------------------------------------------

--- a/purenes/ppu.py
+++ b/purenes/ppu.py
@@ -167,10 +167,10 @@ class _Address(ctypes.Union):
             "_PPUADDRESS",
             (ctypes.LittleEndianStructure,),
             {"_fields_": [
-                ("coarse_x",  ctypes.c_uint8, 5),
-                ("coarse_y",  ctypes.c_uint8, 5),
-                ("nt_select", ctypes.c_uint8, 2),
-                ("fine_y",    ctypes.c_uint8, 3),
+                ("coarse_x",  ctypes.c_uint16, 5),
+                ("coarse_y",  ctypes.c_uint16, 5),
+                ("nt_select", ctypes.c_uint16, 2),
+                ("fine_y",    ctypes.c_uint16, 3),
             ]}
         )),
         ("reg", ctypes.c_uint16)]

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import semver
 from setuptools import setup
 from setuptools import find_packages
 
-version = semver.VersionInfo.parse('0.17.1')
+version = semver.VersionInfo.parse('0.17.2')
 
 setup(name='purenes',
       version=str(version),

--- a/tests/ppu/test_ppu.py
+++ b/tests/ppu/test_ppu.py
@@ -103,9 +103,9 @@ class TestPPU(object):
         # Verifies on the first write vram_temp is updated correctly and the
         # write_latch is set to 1 and on the second write verifies the internal
         # write_latch is set to 0 and the full address is transferred from
-        # t -> v.
+        # t -> v and all of the flags are set correctly.
         address = 0x2006
-        test_object.read(0x2002)  # Init/reset write latch
+        vram_address = (data << 8) | data  # Full 16-bit address
 
         vram = test_object.vram
         vram_temp = test_object.vram_temp
@@ -123,6 +123,10 @@ class TestPPU(object):
         # Verify v: <...all bits...> <- t: <...all bits...>
         assert(vram.reg == vram_temp.reg)
         assert(test_object.write_latch == 0)
+        # Assert flags set correctly
+        assert(vram.flags.coarse_x == vram_address & 0x1F)
+        assert(vram.flags.coarse_y == (vram_address >> 5) & 0x1F)
+        assert(vram.flags.nt_select == (vram_address >> 10) & 0x03)
 
     def test_data_write_x_increment(self, test_object, mock_ppu_bus, mocker):
         # Test PPUDATA $2007 write x increment.


### PR DESCRIPTION
### Notes

The register (reg) value in the union for the _Address class was a 16-bit values and the individual flags were 8-bit values. A union is the size of its largest value, and this type mismatch was causing incorrect values to be stored in coarse_y, nt_select and fine_y. This change updates all of the values in the bitfield struct to be 16-bit values to prevent this. Unit tests have been added to cover this test case.

### Testing
* pytest