### PR TITLE
Implement MVP clock method

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,7 +22,7 @@ copyright = '2022, Stephen Brady'
 author = 'Stephen Brady'
 
 # The full version, including alpha/beta/rc tags
-release = '0.17.3'
+release = '0.18.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import semver
 from setuptools import setup
 from setuptools import find_packages
 
-version = semver.VersionInfo.parse('0.17.3')
+version = semver.VersionInfo.parse('0.18.0')
 
 setup(name='purenes',
       version=str(version),

--- a/tests/ppu/test_ppu.py
+++ b/tests/ppu/test_ppu.py
@@ -25,6 +25,36 @@ class TestPPU(object):
         assert test_object.vram_temp.reg == 0
         assert test_object.write_latch == 0
 
+    def test_coarse_x_increment(self, test_object):
+        # Test coarse_x increment without scrolling offsets
+        #
+        # Sets coarse_x = 0 and clocks the PPU 256 times. Verifies that
+        # coarse_x is 31 (the last tile of the nametable) and that the
+        # nametable address was not wrapped around.
+        test_object.write(0x2006, 0x20)
+        test_object.write(0x2006, 0x00)
+
+        for i in range(0, 257):
+            test_object.clock()
+
+        assert test_object.vram.flags.coarse_x == 0x1F
+        assert test_object.vram.flags.nt_select == 0
+
+    def test_coarse_x_increment_wrap(self, test_object):
+        # Test coarse_x increment with scrolling offsets
+        #
+        # Sets coarse_x = 1 and clocks the PPU 256 times. Verifies that
+        # coarse_x is 0 (the first tile of the next nametable) and that the
+        # nametable address is wrapped around.
+        test_object.write(0x2006, 0x20)
+        test_object.write(0x2006, 0x01)
+
+        for i in range(0, 257):
+            test_object.clock()
+
+        assert test_object.vram.flags.coarse_x == 0x00
+        assert test_object.vram.flags.nt_select == 1
+
     # Test internal registers
     @pytest.mark.parametrize("data", list(range(0x00, 0xFF)))
     def test_control_write(self, test_object, data):


### PR DESCRIPTION
### Notes

This change introduces an MVP clock method exposed by the PPU. 

1. Introduce MVP clock method. Every clock of the PPU in this initial implementation will only "respond" to scanlines 1-239 and cycles 1-256 or cycles 321-340. This implementation will only increment coarse x at the end of each rendering cycle.
2. Introduce private _increment_coarse_x method.
3. Add test coverage.

### Testing 
* pytest