### PR TITLE
Define and implement unit test naming guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,44 @@
+# Adding Tests
+
+### Naming Guidelines
+
+The test naming conventions defined in PureNES are based on the ideas
+defined in this [post](https://stackoverflow.com/questions/155436/unit-test-naming-best-practices).
+
+When naming a test, the name should attempt to adhere to the following 
+guidelines: 
+
+* No rigid naming policy
+* Name the test as if you were describing the scenario to a non-programmer
+* Separate words by underscores
+
+The name of the test should describe what it accomplishes without including 
+technical details that may change over time. 
+
+**Note:** The test must still include the "test" prefix to make it discoverable 
+by pytest. 
+
+Bad Examples:
+
+`test_clock_scanline_260_resets_scanline_counter`
+
+`test_clock_cycle_340_resets_cycle_counter`
+
+`test_read_invalid_address_throws_exception`
+
+
+Good Examples (same test names adjusted to adhere to naming guidelines):
+
+`test_scanline_resets_at_maximum`
+
+`test_cycle_resets_at_maximum`
+
+`test_read_from_an_incorrect_address_is_invalid`
+
+
+More information about this naming policy can be found in this 
+[article](https://enterprisecraftsmanship.com/posts/you-naming-tests-wrong/).
+
 # Versioning 
 
 This package uses [semantic versioning](https://semver.org/).

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,7 +22,7 @@ copyright = '2022, Stephen Brady'
 author = 'Stephen Brady'
 
 # The full version, including alpha/beta/rc tags
-release = '0.19.3'
+release = '0.19.4'
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import semver
 from setuptools import setup
 from setuptools import find_packages
 
-version = semver.VersionInfo.parse('0.19.3')
+version = semver.VersionInfo.parse('0.19.4')
 
 setup(name='purenes',
       version=str(version),

--- a/tests/cpu/test_cpu.py
+++ b/tests/cpu/test_cpu.py
@@ -5,8 +5,10 @@ from purenes.cpu import CPU
 
 class TestCPU(object):
 
-    def test_clock(self, mocker: MockFixture):
-        """Test CPU reset sets the program counter with the values stored at
+    def test_reset(self, mocker: MockFixture):
+        """Test CPU reset cycle.
+
+        Verifies the program counter is updated with the values stored at
         the reset vector addresses and the next CPU clock reads from the
         CPUBus using the address stored in the program counter.
         """

--- a/tests/cpu/test_cpu_bus.py
+++ b/tests/cpu/test_cpu_bus.py
@@ -37,7 +37,10 @@ class TestCpuBus(object):
 
             assert test_object.read(address) == data
 
-    def test_read_invalid_address_raises_exception(self, test_object: CPUBus):
+    def test_read_from_an_incorrect_address_is_invalid(
+            self,
+            test_object: CPUBus
+    ):
         """Test that a read from an address not in the addressable range of the
         CPU throws an exception.
         """
@@ -48,7 +51,10 @@ class TestCpuBus(object):
 
         assert str(exception.value) == self.INVALID_ADDRESS_EXCEPTION_MESSAGE
 
-    def test_write_invalid_address_raises_exception(self, test_object: CPUBus):
+    def test_write_to_an_incorrect_address_is_invalid(
+            self,
+            test_object: CPUBus
+    ):
         """Test that a write to an address not in the addressable range of the
         CPU throws an exception.
         """

--- a/tests/ppu/test_ppu_bus.py
+++ b/tests/ppu/test_ppu_bus.py
@@ -37,7 +37,10 @@ class TestPPUBus(object):
 
             assert test_object.read(address) == data
 
-    def test_read_invalid_address_raises_exception(self, test_object: PPUBus):
+    def test_read_from_an_incorrect_address_is_invalid(
+            self,
+            test_object: PPUBus
+    ):
         """Test that a read from an address not in the addressable range of the
         PPU throws an exception.
         """
@@ -48,7 +51,10 @@ class TestPPUBus(object):
 
         assert str(exception.value) == self.INVALID_ADDRESS_EXCEPTION_MESSAGE
 
-    def test_write_invalid_address_raises_exception(self, test_object: PPUBus):
+    def test_write_to_an_incorrect_address_is_invalid(
+            self,
+            test_object: PPUBus
+    ):
         """Test that writes to an address not in the addressable range of the
         PPU throws an exception.
         """


### PR DESCRIPTION
### Notes

Defines a set of guidelines to name unit tests and adjusts existing tests to conform to these guidelines. This adjustment aims to make tests more approachable and less prone to name refactoring over time. 

The guidelines are based on the following two posts:

[post 1](https://stackoverflow.com/questions/155436/unit-test-naming-best-practices)
[post 2](https://enterprisecraftsmanship.com/posts/you-naming-tests-wrong/)

### Testing
* pytest
