### PR TITLE
Implement coarse_x reset at cycle 257

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,7 +22,7 @@ copyright = '2022, Stephen Brady'
 author = 'Stephen Brady'
 
 # The full version, including alpha/beta/rc tags
-release = '0.19.4'
+release = '0.20.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/purenes/ppu.py
+++ b/purenes/ppu.py
@@ -328,6 +328,10 @@ class PPU(object):
         # Visible scanline (0-239).
         if -1 <= scanline <= 239:
 
+            if cycle == 257:
+                # Last cycle of visible scanline, reset coarse_x
+                self._vram.flags.coarse_x = self._vram_temp.flags.coarse_x
+
             if (1 <= cycle <= 256) or (321 <= cycle <= 340):
                 # Some of the rendering process repeats itself every 8 cycles
                 # The process does not start until cycle 1, the rendering_cycle

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import semver
 from setuptools import setup
 from setuptools import find_packages
 
-version = semver.VersionInfo.parse('0.19.4')
+version = semver.VersionInfo.parse('0.20.0')
 
 setup(name='purenes',
       version=str(version),

--- a/tests/ppu/test_ppu.py
+++ b/tests/ppu/test_ppu.py
@@ -64,6 +64,20 @@ class TestPPU(object):
         assert test_object.vram.flags.coarse_x == 0x00
         assert test_object.vram.flags.nt_select == 1
 
+    def test_horizontal_coarse_scroll_resets_after_rendering_a_scanline(
+            self,
+            test_object: PPU
+    ):
+        """Tests coarse_x reset at cycle 257 in a scanline during rendering.
+
+        Clocks the PPU 258 times (cycles 0 - 257) and verifies that coarse_x is
+        reset at cycle 257.
+        """
+        for i in range(0, 258):
+            test_object.clock()
+
+        assert test_object.vram.flags.coarse_x == 0
+
     def test_cycle_resets_at_maximum(self, test_object: PPU):
         """Test incrementing of cycles within a scanline resets at the maximum
         and that the scanline is incremented by 1.


### PR DESCRIPTION
### Notes

Resets coarse_x (v) to coarse_x (t) at cycle 257 while the PPU is not in a VBLANK state.

### Testing
* pytest