### PR TITLE
Implement vertical scrolling

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,7 +22,7 @@ copyright = '2022, Stephen Brady'
 author = 'Stephen Brady'
 
 # The full version, including alpha/beta/rc tags
-release = '0.20.0'
+release = '0.21.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import semver
 from setuptools import setup
 from setuptools import find_packages
 
-version = semver.VersionInfo.parse('0.20.0')
+version = semver.VersionInfo.parse('0.21.0')
 
 setup(name='purenes',
       version=str(version),


### PR DESCRIPTION
### Notes

Adds logic to increment coarse_y and fine_y at cycle 256 while the PPU is not in VBLANK and to handle overflows and nametable wrapping.

1. Add private _increment_y method to PPU
2. Add logic to call _increment_y if the cycle is 256
3. Add test coverage
4. Minor version bump 0.20.0 -> 0.21.0

### Testing
* pytest