### PR TITLE
Update _Address register to distinguish between nametables

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,7 +22,7 @@ copyright = '2022, Stephen Brady'
 author = 'Stephen Brady'
 
 # The full version, including alpha/beta/rc tags
-release = '0.21.0'
+release = '0.22.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/purenes/ppu.py
+++ b/purenes/ppu.py
@@ -157,20 +157,22 @@ class _Address(ctypes.Union):
     The values detailed below can be accessed using the
     :attr:`~purenes.ppu._Address.flags` attribute of this class.
 
-    * coarse_x  (XXXXX) - The coarse X value to use when scrolling.
-    * coarse_y  (YYYYY) - The coarse Y value to use when scrolling.
-    * nt_select (NN) - Nametable select.
-    * fine_y    (yyy) - The fine y value to use when scrolling.
+    * coarse_x    (XXXXX) - The coarse X value to use when scrolling.
+    * coarse_y    (YYYYY) - The coarse Y value to use when scrolling.
+    * nt_select_x (N) - Horizontal nametable select.
+    * nt_select_y (N) - Vertical nametable select.
+    * fine_y      (yyy) - The fine y value to use when scrolling.
     """
     _fields_ = [
         ("flags", type(
             "_PPUADDRESS",
             (ctypes.LittleEndianStructure,),
             {"_fields_": [
-                ("coarse_x",  ctypes.c_uint16, 5),
-                ("coarse_y",  ctypes.c_uint16, 5),
-                ("nt_select", ctypes.c_uint16, 2),
-                ("fine_y",    ctypes.c_uint16, 3),
+                ("coarse_x",    ctypes.c_uint16, 5),
+                ("coarse_y",    ctypes.c_uint16, 5),
+                ("nt_select_x", ctypes.c_uint16, 1),
+                ("nt_select_y", ctypes.c_uint16, 1),
+                ("fine_y",      ctypes.c_uint16, 3),
             ]}
         )),
         ("reg", ctypes.c_uint16)]
@@ -407,7 +409,8 @@ class PPU(object):
             if _address == 0x0000:
                 self._control.reg = data
                 nt_select = self._control.flags.base_nt_address
-                self._vram_temp.flags.nt_select = nt_select
+                self._vram_temp.flags.nt_select_x = nt_select & 0x01
+                self._vram_temp.flags.nt_select_y = (nt_select >> 1) & 0x01
 
             elif _address == 0x0001:
                 self._mask.reg = data
@@ -617,7 +620,7 @@ class PPU(object):
         # nametable_select value is inverted (wrapped around).
         if self._vram.flags.coarse_x == 31:
             self._vram.flags.coarse_x = 0
-            self._vram.flags.nt_select ^= 1
+            self._vram.flags.nt_select_x ^= 1
         else:
             self._vram.flags.coarse_x += 1
 
@@ -633,7 +636,7 @@ class PPU(object):
             if self._vram.flags.coarse_y == 29:
                 self._vram.flags.coarse_y = 0
                 # Wrap vertical nametable
-                self._vram.flags.nt_select ^= 0x02
+                self._vram.flags.nt_select_y ^= 1
             # TODO: https://github.com/zeeps31/purenes/issues/48
             else:
                 self._vram.flags.coarse_y += 1

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import semver
 from setuptools import setup
 from setuptools import find_packages
 
-version = semver.VersionInfo.parse('0.21.0')
+version = semver.VersionInfo.parse('0.22.0')
 
 setup(name='purenes',
       version=str(version),

--- a/tests/ppu/test_ppu.py
+++ b/tests/ppu/test_ppu.py
@@ -43,7 +43,7 @@ class TestPPU(object):
             test_object.clock()
 
         assert test_object.vram.flags.coarse_x == 0x1F
-        assert test_object.vram.flags.nt_select == 0
+        assert test_object.vram.flags.nt_select_x == 0
 
     def test_coarse_scroll_horizontal_increment_wraps_around_at_maximum(
             self,
@@ -62,7 +62,7 @@ class TestPPU(object):
             test_object.clock()
 
         assert test_object.vram.flags.coarse_x == 0x00
-        assert test_object.vram.flags.nt_select == 1
+        assert test_object.vram.flags.nt_select_x == 1
 
     def test_horizontal_coarse_scroll_resets_after_rendering_a_scanline(
             self,
@@ -92,7 +92,7 @@ class TestPPU(object):
 
         assert test_object.vram.flags.fine_y == 1
         assert test_object.vram.flags.coarse_y == 0
-        assert test_object.vram.flags.nt_select == 0
+        assert test_object.vram.flags.nt_select_y == 0
 
     def test_vertical_scrolling_overflows_at_maximum(
             self,
@@ -112,7 +112,7 @@ class TestPPU(object):
 
         assert test_object.vram.flags.fine_y == 0
         assert test_object.vram.flags.coarse_y == 1
-        assert test_object.vram.flags.nt_select & 0x02 == 0
+        assert test_object.vram.flags.nt_select_y == 0
 
     def test_vertical_scrolling_wraps_around_nametable_at_maximum(
             self,
@@ -132,7 +132,7 @@ class TestPPU(object):
 
         assert test_object.vram.flags.fine_y == 0
         assert test_object.vram.flags.coarse_y == 0
-        assert (test_object.vram.flags.nt_select & 0x02) >> 1 == 1
+        assert test_object.vram.flags.nt_select_y == 1
 
     def test_cycle_resets_at_maximum(self, test_object: PPU):
         """Test incrementing of cycles within a scanline resets at the maximum
@@ -161,8 +161,8 @@ class TestPPU(object):
     @pytest.mark.parametrize("data", list(range(0x00, 0xFF)))
     def test_write_to_control_register(self, test_object: PPU, data: int):
         """Test write to $2000. Verifies the flags of the control register are
-        updated and that the vram_temp.nt_select attribute is updated when a
-        write to $2000 occurs.
+        updated and that the vram_temp.nt_select_x and vram_temp.nt_select_y
+        attributes are updated when a write to $2000 occurs.
         """
         address = 0x2000
 
@@ -180,7 +180,8 @@ class TestPPU(object):
         assert control.flags.sprite_size == (data >> 5) & 1
         assert control.flags.ppu_leader_follower == (data >> 6) & 1
         assert control.flags.generate_nmi == (data >> 7) & 1
-        assert vram_temp.flags.nt_select == (data >> 0) & 3
+        assert vram_temp.flags.nt_select_x == (data >> 0) & 0x01
+        assert vram_temp.flags.nt_select_y == (data >> 1) & 0x01
 
     @pytest.mark.parametrize("data", list(range(0x00, 0xFF)))
     def test_write_to_mask_register(self, test_object: PPU, data: int):
@@ -276,7 +277,8 @@ class TestPPU(object):
         # Assert flags set correctly
         assert vram.flags.coarse_x == vram_address & 0x1F
         assert vram.flags.coarse_y == (vram_address >> 5) & 0x1F
-        assert vram.flags.nt_select == (vram_address >> 10) & 0x03
+        assert vram.flags.nt_select_x == (vram_address >> 10) & 0x01
+        assert vram.flags.nt_select_y == (vram_address >> 11) & 0x01
 
     def test_write_to_data_register_with_horizontal_increment_mode(
             self,


### PR DESCRIPTION
### Notes

Splits the nt_select into nt_select_x and nt_select_y to allow easier manipulation of these values.

### Testing
* pytest