### PR TITLE
Implement nametable reads during a scanline cycle

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,7 +22,7 @@ copyright = '2022, Stephen Brady'
 author = 'Stephen Brady'
 
 # The full version, including alpha/beta/rc tags
-release = '0.22.0'
+release = '0.23.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/purenes/ppu.py
+++ b/purenes/ppu.py
@@ -294,6 +294,10 @@ class PPU(object):
     # $2007 read buffer used to preserve data across frames.
     _data_read_buffer: int
 
+    # Internal latches used to store values before they are loaded into shift
+    # registers
+    _nametable_latch: int  # A nametable tile ID
+
     # Counters
     _scanline: int = -1  # Current scanline
     _cycle: int = 0      # Current cycle within a scanline
@@ -340,7 +344,9 @@ class PPU(object):
                 # value is decremented by 1 to improve readability.
                 rendering_cycle = (cycle - 1) % 8
                 if rendering_cycle == 0:
-                    pass
+                    # 0x2000 + low 12-bits of (v)
+                    nt_address: int = 0x2000 | (self._vram.reg & 0x0FFF)
+                    self._nametable_latch = self._read(nt_address)
 
                 elif rendering_cycle == 7:
                     (self._increment_y() if cycle == 256

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import semver
 from setuptools import setup
 from setuptools import find_packages
 
-version = semver.VersionInfo.parse('0.22.0')
+version = semver.VersionInfo.parse('0.23.0')
 
 setup(name='purenes',
       version=str(version),


### PR DESCRIPTION
### Notes

Adds functionality to read nametable bytes during scanline cycles. Nametable fetches occur every 8 cycles for cycles 1-256 and 321-340.

### Testing 
* pytest