### PR TITLE
chore: add semantic versioning release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    concurrency: release
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Python Semantic Release
+        uses: relekang/python-semantic-release@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          repository_username: __token__

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,30 +39,39 @@ Good Examples (same test names adjusted to adhere to naming guidelines):
 More information about this naming policy can be found in this 
 [article](https://enterprisecraftsmanship.com/posts/you-naming-tests-wrong/).
 
-# Versioning 
+# Commit Messages 
 
-This package uses [semantic versioning](https://semver.org/).
-Version numbers should adhere to the following:
+This package uses the [python-semantic-release](https://github.com/relekang/python-semantic-release)
+package to handle versioning and releases. Commit messages need to adhere to 
+the [angular commit guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
+to be compatible with the python-semantic-release package. 
 
+To verify that the commit message adheres to the correct guidelines, the 
+following command can be executed. 
 
-Given a version number MAJOR.MINOR.PATCH, increment the:
-
-1. MAJOR version when you make incompatible API changes,
-2. MINOR version when you add functionality in a backwards compatible manner, and
-3. PATCH version when you make backwards compatible bug fixes.
-Additional labels for pre-release and build metadata are available as extensions to the MAJOR.MINOR.PATCH format.
-   
-The version can be checked by performing the following:
-
-#### To check the version
-```
-pysemver check 0.1.0
-```
-
-#### To determine the next version 
+Example commit message:
 
 ```
-pysemver bump [major | minor | patch] 0.1.0
+feat: add semantic versioning
 ```
 
-Once the correct version is determined, it should be updated in `setup.py`
+Testing the version change:
+
+```
+semantic-release print-version
+```
+
+Example output:
+
+```
+0.24.0
+```
+
+If you are still unsure how to describe the change correctly feel free to ask 
+in your PR. 
+
+# Releases
+
+This package is released by the [python-semantic-release](https://github.com/relekang/python-semantic-release)
+package on each push to main. If there are changes that result in a new release
+it will happen when the build is green, and the change is merged into main. 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-semver>=2.13.0
 pytest>=7.1.1
 typing_extensions==4.1.1
 pytest-cov==3.0.0
 pytest-mock==3.7.0
 sphinx==4.5.0
 furo==2022.3.4
+python-semantic-release==7.28.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[semantic_release]
+version_variable = setup.py:__version__,docs/source/conf.py:release
+upload_to_repository = false
+branch = main

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,10 @@
-import semver
 from setuptools import setup
 from setuptools import find_packages
 
-version = semver.VersionInfo.parse('0.23.3')
+__version__ = "0.23.3"
 
 setup(name='purenes',
-      version=str(version),
+      version=__version__,
       description='A NES emulator in Python',
       author='Stephen Brady',
       author_email='stephen.brady86@gmail.com',
@@ -16,9 +15,9 @@ setup(name='purenes',
             "pytest-mock==3.7.0"
       ],
       setup_requires=[
-            "semver>=2.13.0",
             "sphinx==4.5.0",
-            "furo==2022.3.4"
+            "furo==2022.3.4",
+            "python-semantic-release==7.28.1"
       ],
-      packages=find_packages(exclude=["tests"]),
+      packages=find_packages(exclude=["tests", "tests.*"]),
       )


### PR DESCRIPTION
### Notes

This change adds a workflow to perform releases using the python-semantic-release package. This will require that all commit messages adhere to the angular commit guidelines moving forward. All version updates will now be handled by the python-semantic-release package.

1. Adds support for python-semantic-release package
2. Adds a GitHub workflow to perform releases on merges into main.
3. Updates CONTRIBUTING.md to reflect the new change.

### Testing
* Created a [sample workflow](https://github.com/zeeps31/purenes/actions/runs/2250723193) against the semanticRelease branch and verified that it succeeded and performed the release correctly. 