### PR TITLE
feat(ppu): implement palette reads and writes

### DIFF
--- a/tests/ppu/test_ppu_bus.py
+++ b/tests/ppu/test_ppu_bus.py
@@ -20,6 +20,17 @@ class TestPPUBus(object):
 
             assert data == 0x00
 
+    def test_read_from_palette_vram(self, ppu_bus: PPUBus):
+        """Tests that reads from palette VRAM for addresses 0x3F00-0x3FFF read
+        the correct values from the correct location.
+        """
+        address_range = [x for x in range(0x3F00, 0x4000)]
+
+        for address in address_range:
+            data: int = ppu_bus.read(address)
+
+            assert data == 0x00
+
     def test_write_to_vram(self, ppu_bus: PPUBus):
         """Test that writes to VRAM for addresses 0x2000-0x2FFF write the
         correct values to the correct location.
@@ -31,6 +42,45 @@ class TestPPUBus(object):
             ppu_bus.write(address, data)
 
             assert ppu_bus.read(address) == data
+
+    def test_write_to_palette_vram(self, ppu_bus: PPUBus):
+        """Tests writes to palette VRAM for addresses 0x3F00-0x3FFF write the
+        correct values to the correct location.
+        """
+        address_range = [x for x in range(0x3F00, 0x4000)]
+
+        for address in address_range:
+            data: int = ppu_bus.read(address)
+
+            assert data == 0x00
+
+    def test_palette_reads_mirror_background(self, ppu_bus: PPUBus):
+        """Tests that reads to addresses 0x3F10, 0x3F14, 0x3F18 and 0x3F1C
+        return the values stored at 0x3F00, 0x3F04, 0x3F08 and 0x3F0C.
+        """
+        ppu_bus.write(0x3F00, 0x00)
+        ppu_bus.write(0x3F04, 0x01)
+        ppu_bus.write(0x3F08, 0x02)
+        ppu_bus.write(0x3F0C, 0x03)
+
+        assert ppu_bus.read(0x3F10) == 0x00
+        assert ppu_bus.read(0x3F14) == 0x01
+        assert ppu_bus.read(0x3F18) == 0x02
+        assert ppu_bus.read(0x3F1C) == 0x03
+
+    def test_palette_writes_mirror_background(self, ppu_bus: PPUBus):
+        """Tests writes to addresses 0x3F00, 0x3F04, 0x3F08 and 0x3F0C store
+        the values in addresses 0x3F10, 0x3F14, 0x3F18 and 0x3F1C.
+        """
+        ppu_bus.write(0x3F10, 0x00)
+        ppu_bus.write(0x3F14, 0x01)
+        ppu_bus.write(0x3F18, 0x02)
+        ppu_bus.write(0x3F1C, 0x03)
+
+        assert ppu_bus.read(0x3F00) == 0x00
+        assert ppu_bus.read(0x3F04) == 0x01
+        assert ppu_bus.read(0x3F08) == 0x02
+        assert ppu_bus.read(0x3F0C) == 0x03
 
     def test_read_from_an_incorrect_address_is_invalid(
             self,


### PR DESCRIPTION
### Notes

Adds support to the PPUBus to read and write color indexes from palette VRAM.

1. Implements reads and writes for addresses $3F00-$3FFF
2. Adds support for background mirroring for addresses $3F10, $3F14, $3F18 and $3F1C
3. Adds test coverage

### Testing
* `pytest`
* `semantic-release print-version` - Verified minor version bump -> 0.28.0