### PR TITLE
feat(cartridge): introduce Cartridge class

### DIFF
--- a/purenes/cartridge.py
+++ b/purenes/cartridge.py
@@ -1,0 +1,124 @@
+try:
+    from typing import TypedDict  # pragma: no cover
+except ImportError:  # pragma: no cover
+    from typing_extensions import TypedDict  # pragma: no cover
+
+from typing import Type
+
+from purenes.mappers import Mapper
+from purenes.mappers import SUPPORTED_MAPPERS
+from purenes.rom import Header
+from purenes.rom import Mirroring
+from purenes.rom import Rom
+
+
+class CartridgeReadOnlyValues(TypedDict):
+    """Read-only container of Cartridge internal values.
+
+    This class should only be used for testing and debugging purposes.
+    """
+    header:      Header
+    mapper_name: str
+
+
+class Cartridge(object):
+    """A class to represent a NES cartridge.
+
+    The Cartridge class is a layer of abstraction around a Mapper. It receives
+    reads and writes from the CPU and PPU and delegates to the active Mapper to
+    perform the operation. The Cartridge, therefore, never accesses PRG and CHR
+    ROM (or RAM if supported by the Mapper) directly but instead relies on the
+    configuration and capabilities of the active Mapper to do so.
+
+    The separate read/write methods for the CPU and PPU are based on the pinout
+    of a NES cartridge connector. The cartridge connector pins were connected
+    directly to the CPU and PPU address and data buses.
+
+    https://www.nesdev.org/wiki/Cartridge_connector.
+
+    Attributes:
+        nt_mirroring (Mirroring): The nametable mirroring mode used by the
+                                  Mapper.
+    """
+
+    def __init__(self, mapper: Mapper):
+        self._mapper = mapper
+        self.nt_mirroring = mapper.rom.header.nt_mirroring
+
+    @classmethod
+    def from_file(cls, file_path: str):
+        """Load a ROM from a file path and create a Cartridge.
+
+        Raises:
+            RuntimeException: Thrown if the ROM requires a Mapper that is not
+                              currently supported.
+        """
+        rom_data: bytes = open(file_path, "rb").read()
+        rom: Rom = Rom(rom_data)
+
+        try:
+            _mapper: Type[Mapper] = SUPPORTED_MAPPERS[rom.header.mapper_id]
+            mapper: Mapper = _mapper(rom)
+
+        except KeyError:
+            raise RuntimeError("The ROM provided uses iNES Mapper: "
+                               "{mapper_id}. This Mapper is not currently "
+                               "supported."
+                               .format(mapper_id=rom.header.mapper_id))
+        
+        return cls(mapper)
+
+    def cpu_read(self, address: int) -> int:
+        """Read PRG data from the Mapper used by this Cartridge.
+
+        Args:
+            address (int): A 16-bit address
+
+        Returns:
+            data (int): An 8-bit value
+        """
+        return self._mapper.cpu_read(address)
+
+    def cpu_write(self, address: int, data: int) -> None:
+        """Write to PRG RAM or internal registers used by the active Mapper.
+
+        Args:
+            address (int): A 16-bit address
+            data (int): An 8-bit value
+
+        Returns:
+            None
+        """
+        self._mapper.cpu_write(address, data)
+
+    def ppu_read(self, address: int) -> int:
+        """Read CHR data from the Mapper used by this Cartridge.
+
+        Args:
+            address (int): A 16-bit address
+
+        Returns:
+            data (int): An 8-bit value
+        """
+        return self._mapper.ppu_read(address)
+
+    def ppu_write(self, address: int, data: int) -> None:
+        """Write to CHR RAM or internal registers used by the active Mapper.
+
+       Args:
+           address (int): A 16-bit address
+           data (int): An 8-bit value
+
+       Returns:
+           None
+       """
+        self._mapper.ppu_write(address, data)
+
+    @property
+    def read_only_values(self) -> CartridgeReadOnlyValues:
+        """Read-only access to internal values for testing and debugging.
+        """
+        return {
+            "header": self._mapper.rom.header,
+            "mapper_name": self._mapper.name
+        }

--- a/purenes/mappers/__init__.py
+++ b/purenes/mappers/__init__.py
@@ -88,3 +88,9 @@ class Mapper(abc.ABC):
 
 
 from purenes.mappers.mapper0 import Mapper0
+from typing import Dict
+from typing import Type
+
+SUPPORTED_MAPPERS: Dict[int, Type[Mapper]] = {
+    0: Mapper0
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,14 @@
 import pytest
-from pytest_mock import MockFixture
 
+from pytest_mock import MockFixture
 from unittest.mock import Mock
+
+
+@pytest.fixture()
+def rom_data() -> bytes:
+    rom: bytes = b'NES\x1a\x02\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+    rom += b'\x00' * (32768 + 8192)  # Dummy data PRG size + CHR size
+    yield rom
 
 
 @pytest.fixture()

--- a/tests/test_cartridge.py
+++ b/tests/test_cartridge.py
@@ -1,0 +1,97 @@
+import math
+from unittest.mock import Mock
+
+import pytest
+from pytest_mock import MockFixture
+
+from purenes.cartridge import Cartridge
+
+
+class TestCartridge(object):
+
+    @pytest.fixture()
+    def mock_mapper(self, mocker: MockFixture):
+        """A Mock to represent a Mapper."""
+        yield mocker.Mock()
+
+    @pytest.fixture()
+    def cartridge(self, mock_mapper):
+        """A Cartridge with a mocked Mapper"""
+        yield Cartridge(mock_mapper)
+
+    def test_from_file_creates_class_correctly(
+            self,
+            rom_data: bytes,
+            mocker: MockFixture):
+        """Tests that the from_file factory method generates a Cartridge as
+        expected.
+
+        Patches the open method and verifies that mocked open function was
+        called with the correct file path and the mapper was loaded correctly.
+        """
+        mock_open = mocker.mock_open(read_data=rom_data)
+        mocker.patch("builtins.open", mock_open)
+
+        cartridge = Cartridge.from_file("test")
+
+        assert isinstance(cartridge, Cartridge)
+        mock_open.assert_called_with("test", "rb")
+
+        assert cartridge.read_only_values["header"].mapper_id == 0
+
+    def test_from_file_with_unsupported_mapper_fails(
+            self,
+            rom_data: bytes,
+            mocker: MockFixture,
+            mock_rom: Mock,
+            mock_header: Mock
+    ):
+        """Tests that loading a Cartridge with an unsupported Mapper throws an
+        exception with the correct exception message.
+        """
+        unsupported_mapper_id = math.inf
+        mock_header.mapper_id = unsupported_mapper_id
+
+        mock_open = mocker.mock_open(read_data=rom_data)
+        mocker.patch("builtins.open", mock_open)
+        mocker.patch("purenes.cartridge.Rom", return_value=mock_rom)
+
+        with pytest.raises(RuntimeError) as exception:
+            Cartridge.from_file("test")
+
+        assert str(exception.value) == ("The ROM provided uses iNES Mapper: "
+                                        "{mapper_id}. This Mapper is not "
+                                        "currently supported.".format(
+                                         mapper_id=unsupported_mapper_id))
+
+    def test_cpu_read(self, cartridge, mock_mapper):
+        """Tests that the Cartridge delegates cpu_read to the
+        Mapper.
+        """
+        cartridge.cpu_read(0x0000)
+
+        mock_mapper.cpu_read.assert_called_with(0x0000)
+
+    def test_cpu_write(self, cartridge, mock_mapper):
+        """Tests that the Cartridge delegates cpu_write to the
+        Mapper.
+        """
+        cartridge.cpu_write(0x0000, 0x00)
+
+        mock_mapper.cpu_write.assert_called_with(0x0000, 0x00)
+
+    def test_ppu_read(self, cartridge, mock_mapper):
+        """Tests that the Cartridge delegates ppu_read to the
+        Mapper.
+        """
+        cartridge.ppu_read(0x0000)
+
+        mock_mapper.ppu_read.assert_called_with(0x0000)
+
+    def test_ppu_write(self, cartridge, mock_mapper):
+        """Tests that the Cartridge delegates ppu_write to the
+        Mapper.
+        """
+        cartridge.ppu_write(0x0000, 0x00)
+
+        mock_mapper.ppu_write.assert_called_with(0x0000, 0x00)

--- a/tests/test_rom.py
+++ b/tests/test_rom.py
@@ -7,12 +7,6 @@ from purenes.rom import Mirroring
 
 class TestRom(object):
 
-    @pytest.fixture()
-    def rom_data(self) -> bytes:
-        rom: bytes = b'NES\x1a\x02\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-        rom += b'\x00' * (32768 + 8192)  # Dummy data PRG size + CHR size
-        yield rom
-
     def test_header_is_extracted_correctly(self, rom_data):
         """Tests that header data is correctly extracted from the header bytes.
         """


### PR DESCRIPTION
### Notes

Adds a Cartridge class that is capable of loading a .nes file and selecting the appropriate Mapper from the header. The Cartridge exposes cpu and ppu read/write methods that the CPU and PPU will use to interact with the Cartridge. Some refactoring is done to the test configurations to allow some fixtures to be shared between tests.

1. Adds Cartridge class.
2. Adds a SUPPORTED_MAPPERS constant to the mappers sub-package to expose a list of mappers that are currently supported.
3. Moves the conftest.py used to configure the mapper tests to the tests directory so that fixtures can be shared between tests.
4. Adds test coverage for the Cartridge class.

### Testing
* `pytest`