### PR TITLE
chore: temporarily disable release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: release
 
 on:
   push:
-    branches:
-      - main
+    branches-ignore:
+      - '**' # TODO: https://github.com/zeeps31/purenes/issues/73
 
 jobs:
   release:


### PR DESCRIPTION
Since the package is in a pre-release stage, there are a large number of new features added that result in a release for each. For this reason, the semantic-release workflow has been disabled until the package stabilizes, or is at a stable version.