### PR TITLE
refactor: update import style to align with Google style guide

### DIFF
--- a/purenes/cartridge.py
+++ b/purenes/cartridge.py
@@ -5,11 +5,8 @@ except ImportError:  # pragma: no cover
 
 from typing import Type
 
-from purenes.mappers import Mapper
-from purenes.mappers import SUPPORTED_MAPPERS
-from purenes.rom import Header
-from purenes.rom import Mirroring
-from purenes.rom import Rom
+import purenes.rom
+from purenes import mappers
 
 
 class CartridgeReadOnlyValues(TypedDict):
@@ -17,7 +14,7 @@ class CartridgeReadOnlyValues(TypedDict):
 
     This class should only be used for testing and debugging purposes.
     """
-    header:      Header
+    header:      purenes.rom.Header
     mapper_name: str
 
 
@@ -41,7 +38,7 @@ class Cartridge(object):
                                   Mapper.
     """
 
-    def __init__(self, mapper: Mapper):
+    def __init__(self, mapper: mappers.Mapper):
         self._mapper = mapper
         self.nt_mirroring = mapper.rom.header.nt_mirroring
 
@@ -54,11 +51,12 @@ class Cartridge(object):
                               currently supported.
         """
         rom_data: bytes = open(file_path, "rb").read()
-        rom: Rom = Rom(rom_data)
+        rom: purenes.rom.Rom = purenes.rom.Rom(rom_data)
 
         try:
-            _mapper: Type[Mapper] = SUPPORTED_MAPPERS[rom.header.mapper_id]
-            mapper: Mapper = _mapper(rom)
+            _mapper: Type[mappers.Mapper] = mappers.SUPPORTED_MAPPERS[
+                rom.header.mapper_id]
+            mapper: mappers.Mapper = _mapper(rom)
 
         except KeyError:
             raise RuntimeError("The ROM provided uses iNES Mapper: "

--- a/purenes/mappers/__init__.py
+++ b/purenes/mappers/__init__.py
@@ -1,6 +1,6 @@
 import abc
 
-from purenes.rom import Rom
+import purenes.rom
 
 
 class Mapper(abc.ABC):
@@ -15,8 +15,8 @@ class Mapper(abc.ABC):
     """
     name: str
 
-    def __init__(self, rom: Rom):
-        self.rom: Rom = rom
+    def __init__(self, rom: purenes.rom.Rom):
+        self.rom: purenes.rom.Rom = rom
 
     @abc.abstractmethod
     def cpu_read(self, address: int) -> int:

--- a/purenes/mappers/mapper0.py
+++ b/purenes/mappers/mapper0.py
@@ -1,7 +1,7 @@
-from purenes.mappers import Mapper
+from purenes import mappers
 
 
-class Mapper0(Mapper):
+class Mapper0(mappers.Mapper):
     """Class to represent iNES Mapper0 (NROM).
 
     NROM refers to the Nintendo cartridge boards NES-NROM-128, NES-NROM-256,

--- a/purenes/ppu.py
+++ b/purenes/ppu.py
@@ -9,7 +9,7 @@ import ctypes
 from typing import List
 from typing import Tuple
 
-from purenes.palette import PPU_PALETTE
+from purenes import palette
 
 
 class _Control(ctypes.Union):
@@ -703,7 +703,7 @@ class PPU(object):
         self._at_shift_lo <<= 1
 
     def _generate_pixel(self) -> None:
-        palette: int = 0x00
+        _palette: int = 0x00
 
         if 0 <= self._scanline <= 240 and self._cycle <= 256:
 
@@ -714,13 +714,13 @@ class PPU(object):
 
                 # Create index into palette memory
                 # https://www.nesdev.org/wiki/PPU_palettes
-                palette = ((self._pt_shift_hi & background_mux) << 1 |
+                _palette = ((self._pt_shift_hi & background_mux) << 1 |
                            self._pt_shift_lo & background_mux)
-                palette |= ((self._at_shift_hi & background_mux) << 1 |
+                _palette |= ((self._at_shift_hi & background_mux) << 1 |
                             self._at_shift_lo & background_mux) << 2
 
-            color: Tuple[int, int, int] = PPU_PALETTE[
-                self._read(0x3F00 | palette)
+            color: Tuple[int, int, int] = palette.PPU_PALETTE[
+                self._read(0x3F00 | _palette)
             ]
 
             self._pixel_values[(256 * self._scanline) + self._cycle-1] = color

--- a/purenes/rom.py
+++ b/purenes/rom.py
@@ -1,7 +1,7 @@
-from enum import Enum
+import enum
 
 
-class Mirroring(Enum):
+class Mirroring(enum.Enum):
     HORIZONTAL = 0
     VERTICAL = 1
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
-import pytest
+from unittest import mock
 
-from pytest_mock import MockFixture
-from unittest.mock import Mock
+import pytest
+import pytest_mock
 
 
 @pytest.fixture()
@@ -12,15 +12,15 @@ def rom_data() -> bytes:
 
 
 @pytest.fixture()
-def mock_header(mocker: MockFixture):
+def mock_header(mocker: pytest_mock.MockFixture):
     """A Mock to represent a Header."""
     yield mocker.Mock()
 
 
 @pytest.fixture()
-def mock_rom(mocker: MockFixture, mock_header: Mock):
+def mock_rom(mocker: pytest_mock.MockFixture, mock_header: mock.Mock):
     """A Mock to represent a Rom with a mocked Header."""
-    rom: Mock = mocker.Mock()
+    rom: mock.Mock = mocker.Mock()
     rom.header = mock_header
 
     yield rom

--- a/tests/cpu/conftest.py
+++ b/tests/cpu/conftest.py
@@ -1,26 +1,25 @@
-from unittest.mock import Mock
+from unittest import mock
 
 import pytest
-from pytest_mock import MockFixture
+import pytest_mock
 
-from purenes.cpu import CPU
-from purenes.cpu import CPUBus
+import purenes.cpu
 
 
 @pytest.fixture()
 def cpu_bus():
     """A CPUBus instance."""
-    cpu_bus: CPUBus = CPUBus()
+    cpu_bus: purenes.cpu.CPUBus = purenes.cpu.CPUBus()
     yield cpu_bus
 
 
 @pytest.fixture()
-def mock_cpu_bus(mocker: MockFixture):
+def mock_cpu_bus(mocker: pytest_mock.MockFixture):
     """A Mock to represent the CPUBus."""
     yield mocker.Mock()
 
 
 @pytest.fixture()
-def cpu(mock_cpu_bus: Mock):
+def cpu(mock_cpu_bus: mock.Mock):
     """A CPU instance with a mocked CPUBus."""
-    yield CPU(mock_cpu_bus)
+    yield purenes.cpu.CPU(mock_cpu_bus)

--- a/tests/cpu/test_cpu.py
+++ b/tests/cpu/test_cpu.py
@@ -1,13 +1,17 @@
-from unittest.mock import Mock
+from unittest import mock
 
-from pytest_mock import MockFixture
+import pytest_mock
 
-from purenes.cpu import CPU
+import purenes.cpu
 
 
 class TestCPU(object):
 
-    def test_reset(self, cpu: CPU, mock_cpu_bus: Mock, mocker: MockFixture):
+    def test_reset(
+            self,
+            cpu: purenes.cpu.CPU,
+            mock_cpu_bus: mock.Mock,
+            mocker: pytest_mock.MockFixture):
         """Test CPU reset cycle.
 
         Verifies the program counter is updated with the values stored at

--- a/tests/cpu/test_cpu_bus.py
+++ b/tests/cpu/test_cpu_bus.py
@@ -1,6 +1,6 @@
 import pytest
 
-from purenes.cpu import CPUBus
+import purenes.cpu
 
 
 class TestCpuBus(object):
@@ -9,7 +9,7 @@ class TestCpuBus(object):
                                          "0x10000. Address should "
                                          "be between 0x0000 - 0xFFFF")
 
-    def test_read_from_ram(self, cpu_bus: CPUBus):
+    def test_read_from_ram(self, cpu_bus: purenes.cpu.CPUBus):
         """Test that reads from CPU RAM for addresses 0x0000-0x2000 return
         the correct values.
         """
@@ -20,7 +20,7 @@ class TestCpuBus(object):
 
             assert data == 0x00
 
-    def test_write_to_ram(self, cpu_bus: CPUBus):
+    def test_write_to_ram(self, cpu_bus: purenes.cpu.CPUBus):
         """Test that writes to CPU RAM for addresses 0x0000-0x2000 return
         the correct values.
         """
@@ -34,7 +34,7 @@ class TestCpuBus(object):
 
     def test_read_from_an_incorrect_address_is_invalid(
             self,
-            cpu_bus: CPUBus
+            cpu_bus: purenes.cpu.CPUBus
     ):
         """Test that a read from an address not in the addressable range of the
         CPU throws an exception.
@@ -48,7 +48,7 @@ class TestCpuBus(object):
 
     def test_write_to_an_incorrect_address_is_invalid(
             self,
-            cpu_bus: CPUBus
+            cpu_bus: purenes.cpu.CPUBus
     ):
         """Test that a write to an address not in the addressable range of the
         CPU throws an exception.

--- a/tests/mappers/test_mapper_0.py
+++ b/tests/mappers/test_mapper_0.py
@@ -1,17 +1,20 @@
-from unittest.mock import Mock
+from unittest import mock
 
 import pytest
 
-from purenes.mappers import Mapper0
+from purenes import mappers
 
 
 class TestMapper0(object):
 
     @pytest.fixture()
-    def mapper(self, mock_rom: Mock):
-        yield Mapper0(mock_rom)
+    def mapper(self, mock_rom: mock.Mock):
+        yield mappers.Mapper0(mock_rom)
 
-    def test_cpu_write_is_unsupported(self, mock_rom: Mock, mapper: Mapper0):
+    def test_cpu_write_is_unsupported(
+            self,
+            mock_rom: mock.Mock,
+            mapper: mappers.Mapper0):
         """Tests that writes from the CPU are not supported and throw an
         exception.
         """
@@ -19,7 +22,10 @@ class TestMapper0(object):
         with pytest.raises(RuntimeError):
             mapper.cpu_write(0x00, 0x00)
 
-    def test_ppu_write_is_unsupported(self, mock_rom: Mock, mapper: Mapper0):
+    def test_ppu_write_is_unsupported(
+            self,
+            mock_rom: mock.Mock,
+            mapper: mappers.Mapper0):
         """Tests that writes from the PPU are not supported and throw an
         exception.
         """
@@ -29,9 +35,9 @@ class TestMapper0(object):
 
     def test_cpu_read_with_multiple_prg_banks_does_not_mirror_address(
             self,
-            mock_header: Mock,
-            mock_rom: Mock,
-            mapper: Mapper0
+            mock_header: mock.Mock,
+            mock_rom: mock.Mock,
+            mapper: mappers.Mapper0
     ):
         """Tests addresses are mapped into addresses $8000-$FFFF if there are
         2 program banks on the ROM.
@@ -48,9 +54,9 @@ class TestMapper0(object):
 
     def test_cpu_read_with_a_single_prg_bank_mirrors_address(
             self,
-            mock_header: Mock,
-            mock_rom: Mock,
-            mapper: Mapper0
+            mock_header: mock.Mock,
+            mock_rom: mock.Mock,
+            mapper: mappers.Mapper0
     ):
         """Tests addresses are mirrored for addresses $C000-$FFFF if there is
         1 program bank on the ROM.
@@ -67,8 +73,8 @@ class TestMapper0(object):
 
     def test_ppu_read_does_not_map_address(
             self,
-            mock_rom: Mock,
-            mapper: Mapper0
+            mock_rom: mock.Mock,
+            mapper: mappers.Mapper0
     ):
         """Tests that the ppu_read method does not provide any mapping
         functionality.

--- a/tests/ppu/conftest.py
+++ b/tests/ppu/conftest.py
@@ -1,35 +1,34 @@
-from unittest.mock import Mock
+from unittest import mock
 
 import pytest
-from pytest_mock import MockFixture
+import pytest_mock
 
-from purenes.ppu import PPU
-from purenes.ppu import PPUBus
+import purenes.ppu
 
 
 @pytest.fixture()
 def ppu_bus():
     """A PPUBus instance."""
-    ppu_bus: PPUBus = PPUBus()
+    ppu_bus: purenes.ppu.PPUBus = purenes.ppu.PPUBus()
     yield ppu_bus
 
 
 @pytest.fixture()
-def mock_ppu_bus(mocker: MockFixture):
+def mock_ppu_bus(mocker: pytest_mock.MockFixture):
     """A Mock to represent the PPUBus."""
-    mock_ppu_bus: Mock = mocker.Mock()
+    mock_ppu_bus: mock.Mock = mocker.Mock()
     mock_ppu_bus.read.return_value = 0x00  # Default return value
     yield mock_ppu_bus
 
 
 @pytest.fixture()
-def ppu(mock_ppu_bus: Mock):
+def ppu(mock_ppu_bus: mock.Mock):
     """A PPU instance with a mocked PPUBus."""
-    yield PPU(mock_ppu_bus)
+    yield purenes.ppu.PPU(mock_ppu_bus)
 
 
 @pytest.fixture(autouse=True)
-def before_each(ppu: PPU):
+def before_each(ppu: purenes.ppu.PPU):
     """Reset the PPU between tests so that tests do not interfere with
     each other.
     """

--- a/tests/ppu/test_ppu.py
+++ b/tests/ppu/test_ppu.py
@@ -1,9 +1,9 @@
-from unittest.mock import Mock
+from unittest import mock
 
 import pytest
-from pytest_mock import MockFixture
+import pytest_mock
 
-from purenes.ppu import PPU
+import purenes.ppu
 
 
 class TestPPU(object):
@@ -16,7 +16,7 @@ class TestPPU(object):
 
     TOTAL_VISIBLE_SCANLINE_CYCLES: int = 257
 
-    def test_ppu_reset(self, ppu: PPU):
+    def test_ppu_reset(self, ppu: purenes.ppu.PPU):
         ppu.reset()
 
         values = ppu.read_only_values
@@ -29,9 +29,9 @@ class TestPPU(object):
 
     def test_nametable_reads_during_a_scanline_cycle(
             self,
-            ppu: PPU,
-            mock_ppu_bus: Mock,
-            mocker: MockFixture
+            ppu: purenes.ppu.PPU,
+            mock_ppu_bus: mock.Mock,
+            mocker: pytest_mock.MockFixture
     ):
         """Tests reads to retrieve nametable data during scanline cycles.
 
@@ -63,9 +63,9 @@ class TestPPU(object):
 
     def test_attribute_table_reads_during_a_scanline_cycle(
             self,
-            ppu: PPU,
-            mock_ppu_bus: Mock,
-            mocker: MockFixture
+            ppu: purenes.ppu.PPU,
+            mock_ppu_bus: mock.Mock,
+            mocker: pytest_mock.MockFixture
     ):
         """Tests reads to retrieve attribute table data during scanline cycles.
 
@@ -101,9 +101,9 @@ class TestPPU(object):
 
     def test_pattern_table_reads_during_a_scanline_cycle(
             self,
-            ppu: PPU,
-            mock_ppu_bus: Mock,
-            mocker: MockFixture
+            ppu: purenes.ppu.PPU,
+            mock_ppu_bus: mock.Mock,
+            mocker: pytest_mock.MockFixture
     ):
         """Tests reads to retrieve low and high pattern table tiles during a
         scanline cycle.
@@ -154,7 +154,7 @@ class TestPPU(object):
             any_order=True
         )
 
-    def test_coarse_scroll_horizontal_increment(self, ppu: PPU):
+    def test_coarse_scroll_horizontal_increment(self, ppu: purenes.ppu.PPU):
         """Tests coarse_x increment without scrolling offsets
 
         Verifies that coarse_x is 31 (the last tile of the nametable) and that
@@ -172,7 +172,7 @@ class TestPPU(object):
 
     def test_coarse_scroll_horizontal_increment_wraps_around_at_maximum(
             self,
-            ppu: PPU
+            ppu: purenes.ppu.PPU
     ):
         """Tests coarse_x increment with scrolling offsets
 
@@ -192,7 +192,7 @@ class TestPPU(object):
 
     def test_horizontal_coarse_scroll_resets_after_rendering_a_scanline(
             self,
-            ppu: PPU
+            ppu: purenes.ppu.PPU
     ):
         """Tests coarse_x resets at cycle 257 in a scanline during rendering.
         """
@@ -201,7 +201,7 @@ class TestPPU(object):
 
         assert ppu.read_only_values["vram"].flags.coarse_x == 0
 
-    def test_vertical_scrolling(self, ppu: PPU):
+    def test_vertical_scrolling(self, ppu: purenes.ppu.PPU):
         """Tests vertical scrolling without any vertical scrolling offsets.
 
         Verifies that fine_y is incremented by 1 without overflowing into
@@ -220,7 +220,7 @@ class TestPPU(object):
 
     def test_vertical_scrolling_overflows_at_maximum(
             self,
-            ppu: PPU
+            ppu: purenes.ppu.PPU
     ):
         """Tests vertical scrolling with a fine_y offset of 1 overflows into
         coarse_y after one row of tiles is rendered.
@@ -242,7 +242,7 @@ class TestPPU(object):
 
     def test_vertical_scrolling_wraps_around_nametable_at_maximum(
             self,
-            ppu: PPU
+            ppu: purenes.ppu.PPU
     ):
         """Tests vertical scrolling with a fine_y offset of 1 wraps around the
         nametable after one frame is rendered.
@@ -263,7 +263,7 @@ class TestPPU(object):
         assert vram.flags.coarse_y == 0
         assert vram.flags.nt_select_y == 1
 
-    def test_cycle_resets_at_maximum(self, ppu: PPU):
+    def test_cycle_resets_at_maximum(self, ppu: purenes.ppu.PPU):
         """Tests incrementing of cycles within a scanline resets at the maximum
         and that the scanline is incremented by 1.
 
@@ -276,7 +276,7 @@ class TestPPU(object):
         assert ppu.read_only_values["cycle"] == 0
         assert ppu.read_only_values["scanline"] == 0
 
-    def test_scanline_resets_at_maximum(self, ppu: PPU):
+    def test_scanline_resets_at_maximum(self, ppu: purenes.ppu.PPU):
         """Tests scanline is reset to the pre-render scanline when the maximum
         scanline and scanline cycles have been reached.
         """
@@ -297,11 +297,11 @@ class TestPPU(object):
     )
     def test_shift_registers_while_rendering(
             self,
-            ppu: PPU,
-            mock_ppu_bus: Mock,
-            cycle_count,
-            shift_hi,
-            shift_lo,
+            ppu: purenes.ppu.PPU,
+            mock_ppu_bus: mock.Mock,
+            cycle_count: int,
+            shift_hi: int,
+            shift_lo: int,
     ):
         """Tests shift registers are loaded and shifted correctly during
         rendering cycles.
@@ -321,7 +321,10 @@ class TestPPU(object):
         assert ppu.read_only_values["pt_shift_hi"] == shift_hi
         assert ppu.read_only_values["pt_shift_lo"] == shift_lo
 
-    def test_background_pixel_output(self, ppu: PPU, mock_ppu_bus: Mock):
+    def test_background_pixel_output(
+            self,
+            ppu: purenes.ppu.PPU,
+            mock_ppu_bus: mock.Mock):
         """Tests palette selection and pixel output for one frame.
 
         Returns the same value for all reads to palette memory and verifies

--- a/tests/ppu/test_ppu_bus.py
+++ b/tests/ppu/test_ppu_bus.py
@@ -1,6 +1,6 @@
 import pytest
 
-from purenes.ppu import PPUBus
+from purenes import ppu
 
 
 class TestPPUBus(object):
@@ -9,7 +9,7 @@ class TestPPUBus(object):
                                          "0x10000. Address should "
                                          "be between 0x0000 - 0x3FFF")
 
-    def test_read_from_vram(self, ppu_bus: PPUBus):
+    def test_read_from_vram(self, ppu_bus: ppu.PPUBus):
         """Test that reads from VRAM for addresses 0x2000-0x2FFF return
         the correct values.
         """
@@ -20,7 +20,7 @@ class TestPPUBus(object):
 
             assert data == 0x00
 
-    def test_read_from_palette_vram(self, ppu_bus: PPUBus):
+    def test_read_from_palette_vram(self, ppu_bus: ppu.PPUBus):
         """Tests that reads from palette VRAM for addresses 0x3F00-0x3FFF read
         the correct values from the correct location.
         """
@@ -31,7 +31,7 @@ class TestPPUBus(object):
 
             assert data == 0x00
 
-    def test_write_to_vram(self, ppu_bus: PPUBus):
+    def test_write_to_vram(self, ppu_bus: ppu.PPUBus):
         """Test that writes to VRAM for addresses 0x2000-0x2FFF write the
         correct values to the correct location.
         """
@@ -43,7 +43,7 @@ class TestPPUBus(object):
 
             assert ppu_bus.read(address) == data
 
-    def test_write_to_palette_vram(self, ppu_bus: PPUBus):
+    def test_write_to_palette_vram(self, ppu_bus: ppu.PPUBus):
         """Tests writes to palette VRAM for addresses 0x3F00-0x3FFF write the
         correct values to the correct location.
         """
@@ -54,7 +54,7 @@ class TestPPUBus(object):
 
             assert data == 0x00
 
-    def test_palette_reads_mirror_background(self, ppu_bus: PPUBus):
+    def test_palette_reads_mirror_background(self, ppu_bus: ppu.PPUBus):
         """Tests that reads to addresses 0x3F10, 0x3F14, 0x3F18 and 0x3F1C
         return the values stored at 0x3F00, 0x3F04, 0x3F08 and 0x3F0C.
         """
@@ -68,7 +68,7 @@ class TestPPUBus(object):
         assert ppu_bus.read(0x3F18) == 0x02
         assert ppu_bus.read(0x3F1C) == 0x03
 
-    def test_palette_writes_mirror_background(self, ppu_bus: PPUBus):
+    def test_palette_writes_mirror_background(self, ppu_bus: ppu.PPUBus):
         """Tests writes to addresses 0x3F00, 0x3F04, 0x3F08 and 0x3F0C store
         the values in addresses 0x3F10, 0x3F14, 0x3F18 and 0x3F1C.
         """
@@ -84,7 +84,7 @@ class TestPPUBus(object):
 
     def test_read_from_an_incorrect_address_is_invalid(
             self,
-            ppu_bus: PPUBus
+            ppu_bus: ppu.PPUBus
     ):
         """Test that a read from an address not in the addressable range of the
         PPU throws an exception.
@@ -98,7 +98,7 @@ class TestPPUBus(object):
 
     def test_write_to_an_incorrect_address_is_invalid(
             self,
-            ppu_bus: PPUBus
+            ppu_bus: ppu.PPUBus
     ):
         """Test that writes to an address not in the addressable range of the
         PPU throws an exception.

--- a/tests/ppu/test_ppu_registers.py
+++ b/tests/ppu/test_ppu_registers.py
@@ -1,9 +1,9 @@
-from unittest.mock import Mock
+from unittest import mock
 
 import pytest
-from pytest_mock import MockFixture
+import pytest_mock
 
-from purenes.ppu import PPU
+import purenes.ppu
 
 
 class TestPPURegisters(object):
@@ -14,7 +14,7 @@ class TestPPURegisters(object):
     """
 
     @pytest.mark.parametrize("data", list(range(0x00, 0xFF)))
-    def test_write_to_control_register(self, ppu: PPU, data: int):
+    def test_write_to_control_register(self, ppu: purenes.ppu.PPU, data: int):
         """Test write to $2000. Verifies the flags of the control register are
         updated and that the vram_temp.nt_select_x and vram_temp.nt_select_y
         attributes are updated when a write to $2000 occurs.
@@ -39,7 +39,7 @@ class TestPPURegisters(object):
         assert vram_temp.flags.nt_select_y == (data >> 1) & 0x01
 
     @pytest.mark.parametrize("data", list(range(0x00, 0xFF)))
-    def test_write_to_mask_register(self, ppu: PPU, data: int):
+    def test_write_to_mask_register(self, ppu: purenes.ppu.PPU, data: int):
         """Test PPUMASK $2001 write.
 
         Verifies that all flags are set appropriately for a given input.
@@ -60,7 +60,7 @@ class TestPPURegisters(object):
 
     def test_read_from_status_register_resets_write_latch(
             self,
-            ppu: PPU
+            ppu: purenes.ppu.PPU
     ):
         """Test PPUSTATUS $2002
 
@@ -74,7 +74,7 @@ class TestPPURegisters(object):
         assert ppu.read_only_values["write_latch"] == 0
 
     @pytest.mark.parametrize("data", list(range(0x00, 0xFF)))
-    def test_write_to_scroll_register(self, ppu: PPU, data: int):
+    def test_write_to_scroll_register(self, ppu: purenes.ppu.PPU, data: int):
         """Test PPUSCROLL $2005 write.
 
         Verifies that on the first write to $2005 bits 3-7 of the input data
@@ -101,7 +101,11 @@ class TestPPURegisters(object):
         assert ppu.read_only_values["write_latch"] == 0
 
     @pytest.mark.parametrize("data", list(range(0x00, 0xFF)))
-    def test_write_to_vram_address_register(self, ppu: PPU, data: int):
+    def test_write_to_vram_address_register(
+            self,
+            ppu: purenes.ppu.PPU,
+            data: int
+    ):
         """Test writes to $2006. Writing to $2006 requires two writes to set
         the VRAM address.
 
@@ -137,9 +141,9 @@ class TestPPURegisters(object):
 
     def test_write_to_data_register_with_horizontal_increment_mode(
             self,
-            ppu: PPU,
-            mock_ppu_bus: Mock,
-            mocker: MockFixture
+            ppu: purenes.ppu.PPU,
+            mock_ppu_bus: mock.Mock,
+            mocker: pytest_mock.MockFixture
     ):
         """Test PPUDATA $2007 write x increment.
 
@@ -159,9 +163,9 @@ class TestPPURegisters(object):
 
     def test_write_to_data_register_with_vertical_increment_mode(
             self,
-            ppu: PPU,
-            mock_ppu_bus: Mock,
-            mocker: MockFixture
+            ppu: purenes.ppu.PPU,
+            mock_ppu_bus: mock.Mock,
+            mocker: pytest_mock.MockFixture
     ):
         """Test PPUDATA $2007 write y increment.
 
@@ -183,9 +187,9 @@ class TestPPURegisters(object):
 
     def test_read_from_data_register_with_horizontal_increment_mode(
             self,
-            ppu: PPU,
-            mock_ppu_bus: Mock,
-            mocker: MockFixture
+            ppu: purenes.ppu.PPU,
+            mock_ppu_bus: mock.Mock,
+            mocker: pytest_mock.MockFixture
     ):
         """Test PPUDATA $2007 x increment.
 
@@ -204,9 +208,9 @@ class TestPPURegisters(object):
 
     def test_read_from_data_register_with_vertical_increment_mode(
             self,
-            ppu: PPU,
-            mock_ppu_bus: Mock,
-            mocker: MockFixture
+            ppu: purenes.ppu.PPU,
+            mock_ppu_bus: mock.Mock,
+            mocker: pytest_mock.MockFixture
     ):
         """Test PPUDATA $2007 y increment.
 
@@ -227,8 +231,8 @@ class TestPPURegisters(object):
 
     def test_read_from_data_register_non_palette_address_buffers_value(
             self,
-            ppu: PPU,
-            mock_ppu_bus: Mock
+            ppu: purenes.ppu.PPU,
+            mock_ppu_bus: mock.Mock
     ):
         """Test PPUDATA $2007 read for non-palette address 0-$3EFF.
 
@@ -253,8 +257,8 @@ class TestPPURegisters(object):
 
     def test_read_from_data_register_palette_address_does_not_buffer_value(
             self,
-            ppu: PPU,
-            mock_ppu_bus: Mock
+            ppu: purenes.ppu.PPU,
+            mock_ppu_bus: mock.Mock
     ):
         """Tests PPUDATA $2007 read for addresses >= $3F00.
 

--- a/tests/test_cartridge.py
+++ b/tests/test_cartridge.py
@@ -1,28 +1,28 @@
 import math
-from unittest.mock import Mock
+from unittest import mock
 
 import pytest
-from pytest_mock import MockFixture
+import pytest_mock
 
-from purenes.cartridge import Cartridge
+import purenes.cartridge
 
 
 class TestCartridge(object):
 
     @pytest.fixture()
-    def mock_mapper(self, mocker: MockFixture):
+    def mock_mapper(self, mocker: pytest_mock.MockFixture):
         """A Mock to represent a Mapper."""
         yield mocker.Mock()
 
     @pytest.fixture()
-    def cartridge(self, mock_mapper):
+    def cartridge(self, mock_mapper: mock.Mock):
         """A Cartridge with a mocked Mapper"""
-        yield Cartridge(mock_mapper)
+        yield purenes.cartridge.Cartridge(mock_mapper)
 
     def test_from_file_creates_class_correctly(
             self,
             rom_data: bytes,
-            mocker: MockFixture):
+            mocker: pytest_mock.MockFixture):
         """Tests that the from_file factory method generates a Cartridge as
         expected.
 
@@ -32,9 +32,9 @@ class TestCartridge(object):
         mock_open = mocker.mock_open(read_data=rom_data)
         mocker.patch("builtins.open", mock_open)
 
-        cartridge = Cartridge.from_file("test")
+        cartridge = purenes.cartridge.Cartridge.from_file("test")
 
-        assert isinstance(cartridge, Cartridge)
+        assert isinstance(cartridge, purenes.cartridge.Cartridge)
         mock_open.assert_called_with("test", "rb")
 
         assert cartridge.read_only_values["header"].mapper_id == 0
@@ -42,9 +42,9 @@ class TestCartridge(object):
     def test_from_file_with_unsupported_mapper_fails(
             self,
             rom_data: bytes,
-            mocker: MockFixture,
-            mock_rom: Mock,
-            mock_header: Mock
+            mocker: pytest_mock.MockFixture,
+            mock_rom: mock.Mock,
+            mock_header: mock.Mock
     ):
         """Tests that loading a Cartridge with an unsupported Mapper throws an
         exception with the correct exception message.
@@ -54,17 +54,21 @@ class TestCartridge(object):
 
         mock_open = mocker.mock_open(read_data=rom_data)
         mocker.patch("builtins.open", mock_open)
-        mocker.patch("purenes.cartridge.Rom", return_value=mock_rom)
+        mocker.patch("purenes.rom.Rom", return_value=mock_rom)
 
         with pytest.raises(RuntimeError) as exception:
-            Cartridge.from_file("test")
+            purenes.cartridge.Cartridge.from_file("test")
 
         assert str(exception.value) == ("The ROM provided uses iNES Mapper: "
                                         "{mapper_id}. This Mapper is not "
                                         "currently supported.".format(
                                          mapper_id=unsupported_mapper_id))
 
-    def test_cpu_read(self, cartridge, mock_mapper):
+    def test_cpu_read(
+            self,
+            cartridge: purenes.cartridge.Cartridge,
+            mock_mapper: mock.Mock
+    ):
         """Tests that the Cartridge delegates cpu_read to the
         Mapper.
         """
@@ -72,7 +76,11 @@ class TestCartridge(object):
 
         mock_mapper.cpu_read.assert_called_with(0x0000)
 
-    def test_cpu_write(self, cartridge, mock_mapper):
+    def test_cpu_write(
+            self,
+            cartridge: purenes.cartridge.Cartridge,
+            mock_mapper: mock.Mock
+    ):
         """Tests that the Cartridge delegates cpu_write to the
         Mapper.
         """
@@ -80,7 +88,10 @@ class TestCartridge(object):
 
         mock_mapper.cpu_write.assert_called_with(0x0000, 0x00)
 
-    def test_ppu_read(self, cartridge, mock_mapper):
+    def test_ppu_read(
+            self,
+            cartridge: purenes.cartridge.Cartridge,
+            mock_mapper: mock.Mock):
         """Tests that the Cartridge delegates ppu_read to the
         Mapper.
         """
@@ -88,7 +99,10 @@ class TestCartridge(object):
 
         mock_mapper.ppu_read.assert_called_with(0x0000)
 
-    def test_ppu_write(self, cartridge, mock_mapper):
+    def test_ppu_write(
+            self,
+            cartridge: purenes.cartridge.Cartridge,
+            mock_mapper: mock.Mock):
         """Tests that the Cartridge delegates ppu_write to the
         Mapper.
         """

--- a/tests/test_rom.py
+++ b/tests/test_rom.py
@@ -1,22 +1,20 @@
 import pytest
 
-from purenes.rom import Rom
-from purenes.rom import Header
-from purenes.rom import Mirroring
+import purenes.rom
 
 
 class TestRom(object):
 
-    def test_header_is_extracted_correctly(self, rom_data):
+    def test_header_is_extracted_correctly(self, rom_data: bytes):
         """Tests that header data is correctly extracted from the header bytes.
         """
-        rom: Rom = Rom(rom_data)
+        rom: purenes.rom.Rom = purenes.rom.Rom(rom_data)
 
-        header: Header = rom.header
+        header: purenes.rom.Header = rom.header
         assert header.chr_banks == 1
         assert header.chr_rom_size == 8192
         assert header.mapper_id == 0
-        assert header.nt_mirroring == Mirroring.VERTICAL
+        assert header.nt_mirroring == purenes.rom.Mirroring.VERTICAL
         assert header.prg_banks == 2
         assert header.prg_rom_size == 32768
         assert header.trainer == 0
@@ -28,31 +26,31 @@ class TestRom(object):
         invalid_header: bytes = b'\x00\x00\x00\x00'
 
         with pytest.raises(RuntimeError) as exception:
-            Rom(invalid_header)
+            purenes.rom.Rom(invalid_header)
 
         assert str(exception.value) == ("Invalid iNES Header. This is not a "
                                         "valid .nes file or this file format "
                                         "is unsupported.")
 
-    def test_read_from_prg_rom(self, rom_data):
+    def test_read_from_prg_rom(self, rom_data: bytes):
         """Tests that reads to CHR ROM return the correct values.
 
         Calls read_prg_rom with last value in the PRG ROM and verifies the
         correct data is returned.
         """
-        rom: Rom = Rom(rom_data)
+        rom: purenes.rom.Rom = purenes.rom.Rom(rom_data)
 
         data: int = rom.read_prg_rom(0x7FFF)
 
         assert data == 0x00
 
-    def test_read_from_chr_rom(self, rom_data):
+    def test_read_from_chr_rom(self, rom_data: bytes):
         """Tests that reads to CHR ROM return the correct values.
 
         Calls read_chr_rom with last value in the CHR ROM and verifies the
         correct data is returned.
         """
-        rom: Rom = Rom(rom_data)
+        rom: purenes.rom.Rom = purenes.rom.Rom(rom_data)
 
         data: int = rom.read_chr_rom(0x1FFF)
 


### PR DESCRIPTION
### Notes

Guidance: Use import statements for packages and modules only, not for individual classes or functions. Classes imported from the typing module, collections.abc module, typing_extensions module, and redirects from the six.moves module are exempt from this rule.

Under circumstances where the name of the module conflicts with a fixture, class variable or instance variable, the full path is used for disambiguation.

### Testing 
* `pytest`