### PR TITLE
Implement BRK with implied addressing

### DIFF
--- a/purenes/cpu.py
+++ b/purenes/cpu.py
@@ -25,7 +25,7 @@ class CPUStatus(ctypes.Union):
     * interrupt_disable (I) - Interrupt disable flag.
     * decimal           (D) - Decimal flag. On the NES, has no effect.
     * brk               (B) - Break flag.
-    * _                 (s) - Unused
+    * na                (s) - Unused
     * overflow          (V) - Overflow flag.
     * negative          (N) - Negative flag.
     """
@@ -277,7 +277,7 @@ class CPU(object):
         operation()
 
     def _imp(self):
-        # Implied addressing mode. In this mode The operand is implied by the
+        # Implied addressing mode. In this mode the operand is implied by the
         # operation.
         return
 

--- a/tests/cpu/test_cpu.py
+++ b/tests/cpu/test_cpu.py
@@ -94,7 +94,8 @@ def test_BRK_with_implied_addressing_mode(
     # The program counter is set to the value at the IRQ vector
     assert cpu.read_only_values["pc"] == 0x0101
 
-    # 3 values are pushed to the stack during this operation
+    # 3 values are pushed to the stack during this operation. The stack pointer
+    # should be decremented by 3 (0xFD-3)
     assert cpu.read_only_values["s"] == 0xFA
 
     assert cpu.status.flags.brk == 1


### PR DESCRIPTION
### Notes

Implements the BRK operation and implied addressing. Since this is the first CPU operation implemented, a number of small changes are included in this change to make this work.

1. Implement BRK operation
2. Implement imp addressing mode
3. Implement _execute_operation now that some operations are available
4. Add a _push_to_stack method to push values to the internal stack
5. Add a _map_operations method to map opcodes to operations
6. Add brk flag to status register
7. Reduce scope of test_reset method, as this will be covered by other tests
8. Add test coverage

### Testing
* `pytest`