### PR TITLE
feat(cpu): implement AND operation

### DIFF
--- a/purenes/cpu.py
+++ b/purenes/cpu.py
@@ -433,6 +433,13 @@ class CPU(object):
 
     # Logical Operations
 
+    def _AND(self):
+        # And with the accumulator
+        self.a &= self.operation_value
+
+        self.status.flags.negative = (self.a & 0x80) != 0
+        self.status.flags.zero = self.a == 0x00
+
     def _ORA(self):
         # OR with the accumulator.
         self.a |= self.operation_value
@@ -572,8 +579,12 @@ class CPU(object):
             0x11: (op._izy, op._ORA, 5), 0x15: (op._zpx, op._ORA, 4),
             0x16: (op._zpx, op._ASL, 6), 0x18: (op._imp, op._CLC, 2),
             0x19: (op._aby, op._ORA, 4), 0x1D: (op._abx, op._ORA, 4),
-            0x1E: (op._abx, op._ASL, 7), 0x30: (op._rel, op._BMI, 2),
-            0x38: (op._imp, op._SEC, 2), 0x50: (op._rel, op._BVC, 2),
+            0x1E: (op._abx, op._ASL, 7), 0x21: (op._izx, op._AND, 6),
+            0x25: (op._zpg, op._AND, 3), 0x29: (op._imm, op._AND, 2),
+            0x2D: (op._abs, op._AND, 4), 0x30: (op._rel, op._BMI, 2),
+            0x31: (op._izy, op._AND, 5), 0x35: (op._zpx, op._AND, 4),
+            0x38: (op._imp, op._SEC, 2), 0x39: (op._aby, op._AND, 4),
+            0x3D: (op._abx, op._AND, 4), 0x50: (op._rel, op._BVC, 2),
             0x58: (op._imp, op._CLI, 2), 0x70: (op._rel, op._BVS, 2),
             0x78: (op._imp, op._SEI, 2), 0x90: (op._rel, op._BCC, 2),
             0xB0: (op._rel, op._BCS, 2), 0xB8: (op._imp, op._CLV, 2),

--- a/tests/cpu/test_cpu_addresing_modes.py
+++ b/tests/cpu/test_cpu_addresing_modes.py
@@ -46,10 +46,12 @@ def test_accumulator_addressing_mode(
     [
         (0x0D, 0x00, 0x01),
         (0x0E, 0x00, 0x01),
+        (0x2D, 0x00, 0x01),
     ],
     ids=[
         "executes_successfully_using_opcode_0x0D",
-        "executes_successfully_using_opcode_0x0E"
+        "executes_successfully_using_opcode_0x0E",
+        "executes_successfully_using_opcode_0x2D"
     ]
 )
 def test_absolute_addressing_mode(
@@ -104,12 +106,16 @@ def test_absolute_addressing_mode(
     [
         (0x19, 0x00, 0x02, 0x04, 0x00, 0x0006, 4),
         (0x1D, 0x02, 0x00, 0x04, 0x00, 0x0006, 4),
+        (0x39, 0x00, 0x02, 0x04, 0x00, 0x0006, 4),
+        (0x3D, 0x02, 0x00, 0x04, 0x00, 0x0006, 4),
         (0x19, 0x00, 0x01, 0xFF, 0x00, 0x0100, 5),
         (0x1D, 0x01, 0x00, 0xFF, 0x00, 0x0100, 5),
     ],
     ids=[
         "executes_successfully_using_opcode_0x19",
         "executes_successfully_using_opcode_0x1D",
+        "executes_successfully_using_opcode_0x39",
+        "executes_successfully_using_opcode_0x3D",
         "adds_an_extra_cycle_if_a_page_boundary_is_crossed_y",
         "adds_an_extra_cycle_if_a_page_boundary_is_crossed_x"
     ]
@@ -177,9 +183,11 @@ def test_indexed_absolute_addressing_modes(
     "opcode, operand",
     [
         (0x09, 0xFF),
+        (0x29, 0xFF),
     ],
     ids=[
         "executes_successfully_using_opcode_0x09",
+        "executes_successfully_using_opcode_0x29",
     ]
 )
 def test_immediate_addressing_mode(
@@ -223,10 +231,12 @@ def test_immediate_addressing_mode(
     "opcode, operand, x_value, value_address_lo, value_address_hi",
     [
         (0x01, 0x00, 0x02, 0x04, 0x00),
+        (0x21, 0x00, 0x02, 0x04, 0x00),
         (0x01, 0xFF, 0x01, 0x04, 0x00),
     ],
     ids=[
         "executes_successfully_using_opcode_0x01",
+        "executes_successfully_using_opcode_0x21",
         "wraps_around_when_the_maximum_value_is_reached"
     ]
 )
@@ -287,10 +297,13 @@ def test_x_indexed_indirect_addressing_mode(
     "effective_address, cycle_count",
     [
         (0x11, 0x00, 0x02, 0x04, 0x00, 0x0006, 5),
+        (0x31, 0x00, 0x02, 0x04, 0x00, 0x0006, 5),
         (0x11, 0x00, 0x01, 0xFF, 0x00, 0x0100, 6),
+
     ],
     ids=[
         "executes_successfully_using_opcode_0x11",
+        "executes_successfully_using_opcode_0x31",
         "adds_an_extra_cycle_if_a_page_boundary_is_crossed"
     ]
 )
@@ -423,11 +436,13 @@ def test_relative_addressing_mode(
     "opcode, operand",
     [
         (0x05, 0xFF),
-        (0x06, 0xFF)
+        (0x06, 0xFF),
+        (0x25, 0xFF)
     ],
     ids=[
         "executes_successfully_using_opcode_0x05",
         "executes_successfully_using_opcode_0x06",
+        "executes_successfully_using_opcode_0x25",
     ]
 )
 def test_zero_page_addressing_mode(
@@ -474,11 +489,13 @@ def test_zero_page_addressing_mode(
     [
         (0x15, 0x01, 0x00, 0x0001),
         (0x16, 0x01, 0x00, 0x0001),
+        (0x35, 0x01, 0x00, 0x0001),
         (0x15, 0x02, 0xFF, 0x0001),
     ],
     ids=[
         "executes_successfully_using_opcode_0x15",
         "executes_successfully_using_opcode_0x16",
+        "executes_successfully_using_opcode_0x35",
         "wraps_around_when_the_maximum_value_is_reached"
     ]
 )

--- a/tests/cpu/test_cpu_operations.py
+++ b/tests/cpu/test_cpu_operations.py
@@ -349,49 +349,67 @@ def test_BRK(
 
 
 @pytest.mark.parametrize(
-    "opcode, accumulator_value, operation_value, negative_flag, zero_flag, "
-    "cycle_count",
+    "opcode, accumulator_value, operation_value, expected_result, "
+    "negative_flag, zero_flag, cycle_count",
     [
-        (0x01, 0x00, 0x01, 0, 0, 6),
-        (0x05, 0x00, 0x01, 0, 0, 3),
-        (0x09, 0x00, 0x01, 0, 0, 2),
-        (0x0D, 0x00, 0x01, 0, 0, 4),
-        (0x15, 0x00, 0x01, 0, 0, 4),
-        (0x19, 0x00, 0x01, 0, 0, 4),
-        (0x1D, 0x00, 0x01, 0, 0, 4),
-        (0x01, 0x00, 0x00, 0, 1, 6),
-        (0x01, 0x00, 0x81, 1, 0, 6),
+        (0x01, 0x00, 0x01, 0x01, 0, 0, 6),
+        (0x05, 0x00, 0x01, 0x01, 0, 0, 3),
+        (0x09, 0x00, 0x01, 0x01, 0, 0, 2),
+        (0x0D, 0x00, 0x01, 0x01, 0, 0, 4),
+        (0x15, 0x00, 0x01, 0x01, 0, 0, 4),
+        (0x19, 0x00, 0x01, 0x01, 0, 0, 4),
+        (0x1D, 0x00, 0x01, 0x01, 0, 0, 4),
+        (0x21, 0x01, 0x01, 0x01, 0, 0, 6),
+        (0x25, 0x01, 0x01, 0x01, 0, 0, 3),
+        (0x29, 0x01, 0x01, 0x01, 0, 0, 2),
+        (0x2D, 0x01, 0x01, 0x01, 0, 0, 4),
+        (0x31, 0x01, 0x01, 0x01, 0, 0, 5),
+        (0x35, 0x01, 0x01, 0x01, 0, 0, 4),
+        (0x39, 0x01, 0x01, 0x01, 0, 0, 4),
+        (0x3D, 0x01, 0x01, 0x01, 0, 0, 4),
+        (0x01, 0x00, 0x00, 0x00, 0, 1, 6),
+        (0x01, 0x00, 0x81, 0x81, 1, 0, 6),
     ],
     ids=[
-        "executes_successfully_using_opcode_0x01",
-        "executes_successfully_using_opcode_0x05",
-        "executes_successfully_using_opcode_0x09",
-        "executes_successfully_using_opcode_0x0D",
-        "executes_successfully_using_opcode_0x15",
-        "executes_successfully_using_opcode_0x19",
-        "executes_successfully_using_opcode_0x1D",
+        "executes_successfully_using_opcode_0x01",  # ORA
+        "executes_successfully_using_opcode_0x05",  # ORA
+        "executes_successfully_using_opcode_0x09",  # ORA
+        "executes_successfully_using_opcode_0x0D",  # ORA
+        "executes_successfully_using_opcode_0x15",  # ORA
+        "executes_successfully_using_opcode_0x19",  # ORA
+        "executes_successfully_using_opcode_0x1D",  # ORA
+        "executes_successfully_using_opcode_0x21",  # AND
+        "executes_successfully_using_opcode_0x25",  # AND
+        "executes_successfully_using_opcode_0x29",  # AND
+        "executes_successfully_using_opcode_0x2D",  # AND
+        "executes_successfully_using_opcode_0x31",  # AND
+        "executes_successfully_using_opcode_0x35",  # AND
+        "executes_successfully_using_opcode_0x39",  # AND
+        "executes_successfully_using_opcode_0x3D",  # AND
         "sets_the_zero_flag_when_the_result_is_zero",
         "sets_the_negative_flag_if_the_result_exceeds_the_signed_8_bit_maximum"
     ]
 )
-def test_ORA(
+def test_logical_operations(
         cpu: purenes.cpu.CPU,
         mock_cpu_bus: mock.Mock,
         mocker: pytest_mock.MockFixture,
         opcode: int,
         accumulator_value: int,
         operation_value: int,
+        expected_result: int,
         negative_flag: int,
         zero_flag: int,
         cycle_count: int
 ):
-    """Tests the ORA (Or with Accumulator) operation.
+    """Tests logical operations (AND, EOR, ORA).
 
     Clocks the CPU and verifies that the following actions are performed during
     the ORA operation.
 
     1. The operation is mapped to the correct opcode.
-    2. The accumulator register is correctly ORed with the operation value.
+    2. The result of performing the logical operation on the accumulator is the
+       expected result.
     3. The negative (N) flag is set under the correct conditions.
     4. The zero (Z) flag is set under the correct conditions.
     """
@@ -405,7 +423,7 @@ def test_ORA(
     for _ in range(0, cycle_count):
         cpu.clock()
 
-    assert cpu.a == accumulator_value | operation_value
+    assert cpu.a == expected_result
     assert cpu.status.flags.negative == negative_flag
     assert cpu.status.flags.zero == zero_flag
     assert cpu.remaining_cycles == 0


### PR DESCRIPTION
### Notes

1. Implements AND operation for all addressing modes supported by the operation.
2. Merges all logical operation tests into one, as the logic is the same for each. 
3. Adds test coverage.

### Testing
* `pytest`