### PR TITLE
feat(cpu): implement STX and y-indexed zero-page addressing

### DIFF
--- a/purenes/cpu.py
+++ b/purenes/cpu.py
@@ -456,7 +456,22 @@ class CPU(object):
         self.effective_address = (operand + self.x) & 0x00FF
         self.operation_value = self._read(self.effective_address)
 
+    def _zpy(self):
+        # Zero page Y indexed addressing mode. Address is operand + Y without
+        # carry.
+        operand: int = self._read(self.pc)
+        self.pc += 1
+
+        self.effective_address = (operand + self.y) & 0x00FF
+        self.operation_value = self._read(self.effective_address)
+
     # Operations
+
+    # Transfer Instructions
+
+    def _STX(self):
+        # Store Index X in Memory
+        self._write(self.effective_address, self.x)
 
     # Stack Instructions
 
@@ -635,7 +650,8 @@ class CPU(object):
             0x50: (op._rel, op._BVC, 2), 0x58: (op._imp, op._CLI, 2),
             0x6C: (op._ind, op._JMP, 5), 0x70: (op._rel, op._BVS, 2),
             0x78: (op._imp, op._SEI, 2), 0x90: (op._rel, op._BCC, 2),
-            0xB0: (op._rel, op._BCS, 2), 0xB8: (op._imp, op._CLV, 2),
-            0xD0: (op._rel, op._BNE, 2), 0xD8: (op._imp, op._CLD, 2),
-            0xF0: (op._rel, op._BEQ, 2), 0xF8: (op._imp, op._SED, 2),
+            0x96: (op._zpy, op._STX, 4), 0xB0: (op._rel, op._BCS, 2),
+            0xB8: (op._imp, op._CLV, 2), 0xD0: (op._rel, op._BNE, 2),
+            0xD8: (op._imp, op._CLD, 2), 0xF0: (op._rel, op._BEQ, 2),
+            0xF8: (op._imp, op._SED, 2),
         }

--- a/tests/cpu/test_cpu_addresing_modes.py
+++ b/tests/cpu/test_cpu_addresing_modes.py
@@ -551,41 +551,45 @@ def test_zero_page_addressing_mode(
 
 
 @pytest.mark.parametrize(
-    "opcode, x_value, operand, effective_address",
+    "opcode, x_value, y_value, operand, effective_address",
     [
-        (0x15, 0x01, 0x00, 0x0001),
-        (0x16, 0x01, 0x00, 0x0001),
-        (0x35, 0x01, 0x00, 0x0001),
-        (0x15, 0x02, 0xFF, 0x0001),
+        (0x15, 0x01, 0x00, 0x00, 0x0001),
+        (0x16, 0x01, 0x00, 0x00, 0x0001),
+        (0x35, 0x01, 0x00, 0x00, 0x0001),
+        (0x96, 0x00, 0x01, 0x00, 0x0001),
+        (0x15, 0x02, 0x00, 0xFF, 0x0001),
     ],
     ids=[
         "executes_successfully_using_opcode_0x15",
         "executes_successfully_using_opcode_0x16",
         "executes_successfully_using_opcode_0x35",
+        "executes_successfully_using_opcode_0x96",
         "wraps_around_when_the_maximum_value_is_reached"
     ]
 )
-def test_zero_page_x_indexed_addressing_mode(
+def test_zero_page_indexed_addressing_mode(
         cpu: purenes.cpu.CPU,
         mock_cpu_bus: mock.Mock,
         mocker: pytest_mock.MockFixture,
         opcode: int,
         x_value: int,
+        y_value: int,
         operand: int,
         effective_address: int):
-    """Tests zero-page x-indexed addressing mode.
+    """Tests zero-page indexed addressing modes (x and y).
 
     Verifies the following:
 
     1. The addressing mode is mapped to the correct opcode.
-    2. The effective address is set to 0x00 + operand + x
+    2. The effective address is set to 0x00 + operand + x or y register
     3. The effective address does not cross pages if the the value of
-       operand + x exceeds the unsigned 8-bit maximum.
+       operand + index exceeds the unsigned 8-bit maximum.
     """
     mocker.patch.object(cpu, "_execute_operation")
 
     cpu.pc = 0x0000
     cpu.x = x_value
+    cpu.y = y_value
     operand: int = operand
 
     mock_cpu_bus.read.side_effect = [


### PR DESCRIPTION
### Notes

1. Implements zero-page addressing and STX operation to accompany the addressing mode.
2. Combines x and y zero-page indexed addressing mode tests into one test.
3. Adds test coverage for STX operation and y-indexed zero-page addressing mode.

### Testing
* `pytest`